### PR TITLE
feat: Home page with navigation

### DIFF
--- a/app/home/layout.tsx
+++ b/app/home/layout.tsx
@@ -1,0 +1,16 @@
+import { AcmeLogo } from '../ui/acme-logo';
+import TripCard from '../ui/home/trip-card';
+ 
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="flex h-screen flex-col md:flex-row md:overflow-hidden">
+      <div className="flex h-20 shrink-0 items-end rounded-lg bg-blue-500 p-4 md:h-52">
+        <AcmeLogo />
+      </div>
+      <div className="flex-grow p-6 md:overflow-y-auto md:p-12">
+        <TripCard />
+      </div>
+      <div className="flex-grow p-6 md:overflow-y-auto md:p-12">{children}</div>
+    </div>
+  );
+}

--- a/app/home/layout.tsx
+++ b/app/home/layout.tsx
@@ -1,14 +1,10 @@
-import { AcmeLogo } from '../ui/acme-logo';
-import TripCard from '../ui/home/trip-card';
+import { AcmeLogoSmall } from '../ui/acme-logo';
  
 export default function Layout({ children }: { children: React.ReactNode }) {
   return (
     <div className="flex h-screen flex-col md:flex-row md:overflow-hidden">
-      <div className="flex h-20 shrink-0 items-end rounded-lg bg-blue-500 p-4 md:h-52">
-        <AcmeLogo />
-      </div>
-      <div className="flex-grow p-6 md:overflow-y-auto md:p-12">
-        <TripCard />
+      <div className="flex flex-col px-3 py-4 md:px-2 items-center">
+        <AcmeLogoSmall />
       </div>
       <div className="flex-grow p-6 md:overflow-y-auto md:p-12">{children}</div>
     </div>

--- a/app/home/page.tsx
+++ b/app/home/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+    return <p>Home Page</p>;
+  }

--- a/app/home/page.tsx
+++ b/app/home/page.tsx
@@ -1,3 +1,9 @@
+import TripCard from '../ui/home/trip-card';
+
 export default function Page() {
-    return <p>Home Page</p>;
+    return (
+      <div className="flex-grow p-6 md:overflow-y-auto md:p-12">
+        <TripCard />
+      </div>
+    );
   }

--- a/app/ui/acme-logo.tsx
+++ b/app/ui/acme-logo.tsx
@@ -1,13 +1,23 @@
 import { GlobeAltIcon } from '@heroicons/react/24/outline';
 import { galada } from '@/app/ui/fonts';
 
-export default function AcmeLogo() {
+export function AcmeLogo() {
   return (
-    <div
-      className={`${galada.className} flex flex-row items-center leading-none text-white`}
-    >
+    <div className={`${galada.className} flex flex-row items-center leading-none text-white`}>
       <GlobeAltIcon className="h-12 w-12 rotate-[15deg]" />
-      <p className="text-[44px]">Tripwell</p>
+      <p className="text-[44px]">
+        Tripwell
+      </p>
+    </div>
+  );
+}
+
+export function AcmeLogoSmall() {
+  return (
+    <div className={`${galada.className} flex flex-row items-center leading-none`}>
+      <p className="text-[28px] text-blue-600 justify-center">
+        Tripwell
+      </p>
     </div>
   );
 }

--- a/app/ui/dashboard/sidenav.tsx
+++ b/app/ui/dashboard/sidenav.tsx
@@ -1,28 +1,29 @@
 import Link from 'next/link';
 import NavLinks from '@/app/ui/dashboard/nav-links';
-import AcmeLogo from '@/app/ui/acme-logo';
-import { PowerIcon } from '@heroicons/react/24/outline';
+import { AcmeLogoSmall } from '@/app/ui/acme-logo';
+import { ArrowLeftIcon } from '@heroicons/react/24/outline';
 
 export default function SideNav() {
   return (
     <div className="flex h-full flex-col px-3 py-4 md:px-2">
+      <div className="flex h-full flex-col px-3 py-4 md:px-2 items-center">
+        <AcmeLogoSmall />
+      </div>
+      <div className="flex h-full flex-col px-3 py-4 md:px-2 items-center">
+        <p className="text-[40px]">
+          Canada
+        </p>
+      </div>
       <Link
-        className="mb-2 flex h-20 items-end justify-start rounded-md bg-blue-600 p-4 md:h-40"
-        href="/"
+        key={"Home"}
+        href={"/home"}
+        className={'flex h-[64px] grow items-center justify-center gap-2 rounded-md p-3 text-blue-600 text-sm font-medium hover:bg-sky-100 hover:text-blue-600 md:flex-none md:justify-start md:p-2 md:px-3'}
       >
-        <div className="w-32 text-white md:w-40">
-          <AcmeLogo />
-        </div>
+        <ArrowLeftIcon className="ml-auto h-5 w-5 text-blue-600" /> Home
       </Link>
       <div className="flex grow flex-row justify-between space-x-2 md:flex-col md:space-x-0 md:space-y-2">
         <NavLinks />
         <div className="hidden h-auto w-full grow rounded-md bg-gray-50 md:block"></div>
-        <form>
-          <button className="flex h-[48px] w-full grow items-center justify-center gap-2 rounded-md bg-gray-50 p-3 text-sm font-medium hover:bg-sky-100 hover:text-blue-600 md:flex-none md:justify-start md:p-2 md:px-3">
-            <PowerIcon className="w-6" />
-            <div className="hidden md:block">Sign Out</div>
-          </button>
-        </form>
       </div>
     </div>
   );

--- a/app/ui/dashboard/sidenav.tsx
+++ b/app/ui/dashboard/sidenav.tsx
@@ -1,15 +1,11 @@
 import Link from 'next/link';
 import NavLinks from '@/app/ui/dashboard/nav-links';
-import { AcmeLogoSmall } from '@/app/ui/acme-logo';
 import { ArrowLeftIcon } from '@heroicons/react/24/outline';
 
 export default function SideNav() {
   return (
     <div className="flex h-full flex-col px-3 py-4 md:px-2">
-      <div className="flex h-full flex-col px-3 py-4 md:px-2 items-center">
-        <AcmeLogoSmall />
-      </div>
-      <div className="flex h-full flex-col px-3 py-4 md:px-2 items-center">
+      <div className="flex flex-col px-3 py-4 md:px-2 items-center">
         <p className="text-[40px]">
           Canada
         </p>
@@ -17,7 +13,7 @@ export default function SideNav() {
       <Link
         key={"Home"}
         href={"/home"}
-        className={'flex h-[64px] grow items-center justify-center gap-2 rounded-md p-3 text-blue-600 text-sm font-medium hover:bg-sky-100 hover:text-blue-600 md:flex-none md:justify-start md:p-2 md:px-3'}
+        className={'flex h-[64px] w-[90px] grow items-center justify-center gap-2 rounded-md p-3 text-blue-600 text-sm font-medium hover:bg-sky-100 hover:text-blue-600 md:flex-none md:justify-start md:p-2 md:px-3'}
       >
         <ArrowLeftIcon className="ml-auto h-5 w-5 text-blue-600" /> Home
       </Link>

--- a/app/ui/home/trip-card.tsx
+++ b/app/ui/home/trip-card.tsx
@@ -1,0 +1,14 @@
+import Link from "next/link";
+import { ArrowRightIcon } from "@heroicons/react/24/outline";
+
+export default function TripCard() {
+    return (
+        <Link
+            key={"Trip"}
+            href={"/dashboard"}
+            className={'flex h-[64px] grow items-center justify-center gap-2 rounded-md bg-sky-100 p-3 text-blue-600 text-sm font-medium hover:bg-sky-100 hover:text-blue-600 md:flex-none md:justify-start md:p-2 md:px-3'}
+        >
+            Canada <ArrowRightIcon className="ml-auto h-5 w-5 text-blue-600" />
+        </Link>
+    );
+}


### PR DESCRIPTION
* Added new home page to show list of trips
* Tapping on trip now navigates to dashboard page
* New back arrow navigates back to the home page

|New home page|Linked to dashboard|
|-|-|
|<img width="308" alt="Screenshot 2024-03-31 at 1 40 20 PM" src="https://github.com/spencer-dale/tripwell/assets/42852323/f90af800-1dc3-4583-abd1-b876611d4b13">|<img width="309" alt="Screenshot 2024-03-31 at 1 40 35 PM" src="https://github.com/spencer-dale/tripwell/assets/42852323/24bbd195-7fa4-4da1-8d67-4f76b47b0233">|

